### PR TITLE
Update rfvimptest.R

### DIFF
--- a/R/rfvimptest.R
+++ b/R/rfvimptest.R
@@ -130,7 +130,7 @@ rfvimptest <- function(data, yname, Mmax = 500, varnames = NULL, p0 = 0.06, p1 =
   starttime <- Sys.time()
   # @seealso \code{\link{predict.divfor}}
 
-  if(any(is.na(data))) {
+  if(!condinf & any(is.na(data))) {
     missvariables <- paste(names(data)[apply(data, 2, function(x) any(is.na(x)))], collapse = ", ")
     stop(paste0("Missing data in columns: ", missvariables, ". Please provide complete data or consider setting condinf=TRUE."))
   }


### PR DESCRIPTION
Missing values caused to stop the algorithm even when using condinf = TRUE. I modified the relevant stopping rule to make the algorithm proceed in this case.